### PR TITLE
residual terms for linear constraints

### DIFF
--- a/src/descent.jl
+++ b/src/descent.jl
@@ -89,7 +89,7 @@ Base.@kwdef struct SteepestDescentCache{T, DN, NN, EN, AN, HN, GN} <: AbstractSt
     ## caches for intermediate values
     fxn :: Vector{T}
 
-    ## caches for constraint jacobians times normal step
+    ## caches for product of constraint jacobians and normal step
     En :: EN        # E*n
     An :: AN        # A*n
     Hn :: HN        # ∇h(x)*n
@@ -117,13 +117,9 @@ function init_step_cache(
         normal_step_norm = cfg
 
     fxn = undef_or_nothing(vals.fx, T)
-
     En = undef_or_nothing(vals.Ex, T)
-
     An = undef_or_nothing(vals.Ax, T)
-
-    Hn = undef_or_nothing(mod_vals.hx, T)
-    
+    Hn = undef_or_nothing(mod_vals.hx, T)    
     Gn = undef_or_nothing(mod_vals.gx, T)
 
     return SteepestDescentCache(;
@@ -304,8 +300,8 @@ function solve_steepest_descent_problem(
 
     ## A(x + n + d) ≤ b ⇔ A(x+n) + A*d <= b
     ## ⇒ c = A(x+n)
-    set_linear_constraints!(opt, Exn, d, Ab, :eq)
-    set_linear_constraints!(opt, Axn, d, Ec, :ineq)
+    set_linear_constraints!(opt, Exn, d, Ec, :eq)
+    set_linear_constraints!(opt, Axn, d, Ab, :ineq)
 
     ## hx + H(n + d) = 0 ⇔ (hx + Hn) + Hd = 0
     set_linear_constraints!(opt, Hxn, d, Dhx, 0, :eq)

--- a/src/mop.jl
+++ b/src/mop.jl
@@ -96,17 +96,27 @@ nl_ineq_constraints!(y::Nothing, mop::AbstractMOP, x::RVec)=nothing
 nl_eq_constraints!(y::RVec, mop::AbstractMOP, x::RVec)=eval_nl_eq_constraints!(y, mop, x)
 nl_ineq_constraints!(y::RVec, mop::AbstractMOP, x::RVec)=eval_nl_ineq_constraints!(y, mop, x)
 
-# Similar methods can be defined for linear constraints:
-lin_cons!(y::Nothing, cons::Nothing, x::RVec) = nothing
-function lin_cons!(y::RVec, (A, b)::Tuple, x::RVec)
-    LA.mul!(y, A, x)
-    y .-= b
+# Similar methods can be defined for linear constraints.
+"""
+    lin_cons!(residual_vector, prod_cache, constraint_data, x)
+
+Given a linear constraint `A*x .<= b` or `A*x .== b`, compute the product `A*x` and store 
+the result in `prod_cache`, and also compute `A*x .- b` and store the result in 
+`residual_vector`.
+`constraint_data` should either be the tuple `(A,b)::Tuple{RMat,RVec}` or `nothing`.
+"""
+lin_cons!(residual_vector, prod_cache, constraint_data, x)=nothing
+lin_cons!(res::Nothing, mat_vec::Nothing, cons::Nothing, x::RVec) = nothing
+function lin_cons!(res::RVec, mat_vec::RVec, (A, b)::Tuple, x::RVec)
+    LA.mul!(mat_vec, A, x)
+    @. res = mat_vec - b
     return nothing
 end
-lin_eq_constraints!(y::Nothing, mop::AbstractMOP, x::RVec)=nothing
-lin_ineq_constraints!(y::Nothing, mop::AbstractMOP, x::RVec)=nothing
-lin_eq_constraints!(y::RVec, mop::AbstractMOP, x::RVec)=lin_cons!(y, lin_eq_constraints(mop), x)
-lin_ineq_constraints!(y::RVec, mop::AbstractMOP, x::RVec)=lin_cons!(y, lin_ineq_constraints(mop), x)
+# More specific methods with descriptive names applicable to an `AbstractMOP`:
+lin_eq_constraints!(res::Nothing, mat_vec::Nothing, mop::AbstractMOP, x::RVec)=nothing
+lin_ineq_constraints!(res::Nothing, mat_vec::Nothing, mop::AbstractMOP, x::RVec)=nothing
+lin_eq_constraints!(res::RVec, mat_vec::Nothing, mop::AbstractMOP, x::RVec)=lin_cons!(res, mat_vec, lin_eq_constraints(mop), x)
+lin_ineq_constraints!(res::RVec, mat_vec::Nothing, mop::AbstractMOP, x::RVec)=lin_cons!(res, mat_vec, lin_ineq_constraints(mop), x)
 
 # ## Pre-Allocation
 # Why do we also allow `nothing` as the target for constraints?

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,3 +10,6 @@ function vec2str(x, max_entries=typemax(Int), digits=10)
 	x_str *= "]"
 	return x_str
 end
+
+promote_modulo_nothing(T1, ::Type{Nothing})=T1
+promote_modulo_nothing(T1, T2)=Base.promote_type(T1, eltype(T2))


### PR DESCRIPTION
There was a mistake in how linear constraints were handled.
There is now separate caches for residual vectors and matrix-vector-product results.
Needs further testing, but "simple_mop" example works at least.