### PR TITLE
Granular Stopping -- Enables "maximum number of evaluations"

### DIFF
--- a/src/CompromiseEvaluators.jl
+++ b/src/CompromiseEvaluators.jl
@@ -44,7 +44,35 @@ provides_hessians(op::AbstractNonlinearOperator)=false
 # for details.
 supports_partial_evaluation(op::AbstractNonlinearOperator) = false
 
+# Stopping based on the number of evaluations is surprisingly hard if we don't
+# want to give up most of the flexibility and composability of Operators and(/in) Problems
+# and models.
+# To implement such a stopping mechanism, we would like the operator to 
+# count the number of evaluations.
+is_counted(op::AbstractNonlinearOperator)=false
+# If `is_counted` returns true, we assume that we can safely call
+# `num_calls` and get a 3-tuple of values:
+# the number of function evaluations, gradient evaluations and Hessian evaluations:
+num_calls(op::AbstractNonlinearOperator)::Tuple{Int, Int, Int}=nothing
+# In addition, there should be a method to (re-)set the counters:
+set_num_calls!(op::AbstractNonlinearOperator,vals::Tuple{Int,Int,Int})=nothing
+# Stopping based on the number of evaluations is so fundamental, I make it 
+# part of the interface:
+max_calls(op::AbstractNonlinearOperator)::Union{Nothing,NTuple{3, Union{Int,Nothing}}}=nothing
+# If you have `enforce_max_calls` return `true`, then we automatically check the number of 
+# evaluations (or differentiation calls).
+# You then don't have to implement this yourself in `eval_op!` etc.
+enforce_max_calls(op::AbstractNonlinearOperator)=true
+
+# !!! note
+#     Whether or not `max_calls` is respected depends on the implementation of 
+#     `AbstractMOPSurrogate` or the implementation of `update!` for `AbstractSurrogateModel`...
+
+
 # ### Methods for `AbstractNonlinearOperatorWithParams`
+# !!! note 
+#     The evaluation methods should respect `is_counted` and internally increase any counters.
+
 # The methods below should be implemented to evaluate parameter dependent operators: 
 """
     eval_op!(y, op, x, p)
@@ -69,9 +97,12 @@ end
 
 # The combined forward-function `eval_op_and_grads!` is derived from `eval_op!` and 
 # `eval_grads!`, but can be customized easily:
+## helper macro `@serve` instead of `return`
+import ..Compromise: @serve
+
 function eval_op_and_grads!(y, Dy, op::AbstractNonlinearOperatorWithParams, x, p)
-    eval_op!(y, val, x, p)
-    eval_grads!(Dy, val, x, p)
+    @serve eval_op!(y, val, x, p)
+    @serve eval_grads!(Dy, val, x, p)
     return nothing
 end
 
@@ -101,8 +132,8 @@ end
 # is derived from `eval_op_and_grads!` and `eval_hessians!`,
 # but can be customized easily:
 function eval_op_and_grads!(y, Dy, H, op::AbstractNonlinearOperatorWithParams, x, p)
-    eval_op_and_grads!(Dy, y, op, x, p)
-    eval_hessians!(H, val, x, p)
+    @serve eval_op_and_grads!(Dy, y, op, x, p)
+    @serve eval_hessians!(H, val, x, p)
     return nothing
 end
 
@@ -119,16 +150,16 @@ function partial_grads!(Dy, op::AbstractNonlinearOperatorWithParams, x, p, outpu
     return error("Partial Jacobian not implemented.")
 end
 function partial_op_and_grads!(y, Dy, op::AbstractNonlinearOperatorWithParams, x, p, outputs)
-    partial_op!(y, op, x, p, outputs)
-    partial_grads!(Dy, op, x, p, outputs)
+    @serve partial_op!(y, op, x, p, outputs)
+    @serve partial_grads!(Dy, op, x, p, outputs)
     return nothing
 end
 function partial_hessians!(H, op::AbstractNonlinearOperatorWithParams, x, p, outputs)
     return error("Partial Hessians not implemented.")
 end
 function partial_op_and_grads_and_hessians!(y, Dy, H, op::AbstractNonlinearOperatorWithParams, x, p, outputs)
-    partial_op_and_grads!(y, Dy, op, x, p, outputs)
-    partial_hessians!(H, op, x, p, outputs)
+    @serve partial_op_and_grads!(y, Dy, op, x, p, outputs)
+    @serve partial_hessians!(H, op, x, p, outputs)
     return nothing
 end
 
@@ -137,36 +168,58 @@ end
 # Note, that these are defined for `AbstractNonlinearOperator`.
 # By implementing the parametric-interface for `AbstractNonlinearOperatorNoParams`, 
 # they work out-of-the box for non-paremetric operators, too:
-function func_vals!(y, op::AbstractNonlinearOperator, x, p, outputs=nothing)
+function check_num_calls(op, ind; force::Bool=enforce_max_calls(op))
+    !is_counted(op) && return nothing
+    !force && return nothing
+    max_call_tuple = max_calls(op)
+    isnothing(max_call_tuple) && return nothing
+    ncalls = num_calls(op)
+    for i=ind
+        ni = ncalls[i]
+        mi = max_call_tuple[i]
+        isnothing(mi) && continue
+        if ni >= mi
+            return "Maximum evaluation count reached, order=$(i-1), evals $(ni) >= $(mi)."
+        end
+    end
+    return nothing
+end
+
+function func_vals!(y, op::AbstractNonlinearOperator, x, p; outputs=nothing)
+    @serve check_num_calls(op, 1)
     if !isnothing(outputs) && supports_partial_evaluation(op)
-        partial_op!(y, op, x, p, outputs)
+        return partial_op!(y, op, x, p, outputs)
     end
     return eval_op!(y, op, x, p)
 end
-function func_grads!(Dy, op::AbstractNonlinearOperator, x, p, outputs=nothing)
+function func_grads!(Dy, op::AbstractNonlinearOperator, x, p; outputs=nothing)
+    @serve check_num_calls(op, 2)
     if !isnothing(outputs) && supports_partial_evaluation(op)
-        partial_grads!(Dy, op, x, p, outputs)
+        return partial_grads!(Dy, op, x, p, outputs)
     end
     return eval_grads!(Dy, op, x, p)
 end
-function func_vals_and_grads!(y, Dy, op::AbstractNonlinearOperator, x, p, outputs=nothing)
+function func_vals_and_grads!(y, Dy, op::AbstractNonlinearOperator, x, p; outputs=nothing)
+    @serve check_num_calls(op, (1,2))
     if !isnothing(outputs) && supports_partial_evaluation(op)
-        partial_op_and_grads!(y, Dy, op, x, p, outputs)
+        return partial_op_and_grads!(y, Dy, op, x, p, outputs)
     end
     return eval_op_and_grads!(y, Dy, op, x, p)
 end
-function func_hessians!(H, op::AbstractNonlinearOperator, x, p, outputs=nothing)
+function func_hessians!(H, op::AbstractNonlinearOperator, x, p; outputs=nothing)
+    @serve check_num_calls(op, 3)
     if !isnothing(outputs) && supports_partial_evaluation(op)
-        partial_hessians!(H, op, x, p, outputs)
+        return partial_hessians!(H, op, x, p, outputs)
     end
     return eval_hessians!(H, op, x, p)
 end
 function func_vals_and_grads_and_hessians!(
-    y, Dy, H, op::AbstractNonlinearOperator, x, p, outputs=nothing)
+    y, Dy, H, op::AbstractNonlinearOperator, x, p; outputs=nothing)
+    @serve check_num_calls(op, (1,2,3))
     if !isnothing(outputs) && supports_partial_evaluation(op)
-        partial_op_and_grads_and_hessians!(y, Dy, H, op, x, p, outputs)
+        return partial_op_and_grads_and_hessians!(y, Dy, H, op, x, p, outputs)
     end
-    eval_op_and_grads_and_hessians!(y, Dy, H, op, x, p)
+    return eval_op_and_grads_and_hessians!(y, Dy, H, op, x, p)
 end
 
 # ### Methods `AbstractNonlinearOperatorNoParams`
@@ -187,8 +240,8 @@ function eval_grads!(Dy, op::AbstractNonlinearOperatorNoParams, x)
 end
 # Optional, derived method for values and gradients:
 function eval_op_and_grads!(y, Dy, op::AbstractNonlinearOperatorNoParams, x)
-    eval_op!(y, op, x)
-    eval_grads!(Dy, op, x)
+    @serve eval_op!(y, op, x)
+    @serve eval_grads!(Dy, op, x)
     return nothing
 end
 # Same for Hessians:
@@ -196,8 +249,8 @@ function eval_hessians!(H, op::AbstractNonlinearOperatorNoParams, x)
     return error("No implementation of `eval_hessians!` for operator $op.")
 end
 function eval_op_and_grads_and_hessians!(y, Dy, H, op::AbstractNonlinearOperatorNoParams, x)
-    eval_op_and_grads!(y, Dy, op, x)
-    eval_hessians!(H, op, x)
+    @serve eval_op_and_grads!(y, Dy, op, x)
+    @serve eval_hessians!(H, op, x)
     return nothing
 end
 # Some operators might support partial evaluation. 
@@ -209,37 +262,17 @@ function partial_grads!(Dy, op::AbstractNonlinearOperatorNoParams, x, outputs)
     return error("Partial Jacobian not implemented.")
 end
 function partial_op_and_grads!(y, Dy, op::AbstractNonlinearOperatorNoParams, x, outputs)
-    partial_op!(y, op, x, outputs)
-    partial_grads!(Dy, op, x, outputs)
+    @serve partial_op!(y, op, x, outputs)
+    @serve partial_grads!(Dy, op, x, outputs)
     return nothing
 end
 function partial_hessians!(H, op::AbstractNonlinearOperatorNoParams, x, outputs)
     return error("Partial Hessians not implemented.")
 end
 function partial_op_and_grads_and_hessians!(y, Dy, H, op::AbstractNonlinearOperatorNoParams, x, outputs)
-    partial_op_and_grads!(y, Dy, op, x, outputs)
-    partial_hessians!(H, op, x, outputs)
+    @serve partial_op_and_grads!(y, Dy, op, x, outputs)
+    @serve partial_hessians!(H, op, x, outputs)
     return nothing
-end
-
-# The safe-guarded methods simply forward to the parametric versions and pass `nothing`
-# parameters:
-function func_vals!(y, op::AbstractNonlinearOperatorNoParams, x, outputs=nothing)
-    return func_vals!(y, op, x, nothing, outputs)
-end
-function func_grads!(Dy, op::AbstractNonlinearOperatorNoParams, x, outputs=nothing)
-    return func_grads!(Dy, op, x, nothing, outputs)
-end
-function func_vals_and_grads!(y, Dy, op::AbstractNonlinearOperatorNoParams, x, outputs=nothing)
-    return func_vals_and_grads!(y, Dy, op, x, nothing, outputs)
-end
-function func_hessians!(H, op::AbstractNonlinearOperatorNoParams, x, outputs=nothing)
-    return func_hessians!(H, op, x, nothing, outputs)
-end
-function func_vals_and_grads_and_hessians!(
-    y, Dy, H, op::AbstractNonlinearOperatorNoParams, x, outputs=nothing
-)
-    return func_vals_and_grads_and_hessians!(y, Dy, H, op, x, nothing, outputs)
 end
 
 # #### Parameter-Methods for Non-Parametric Operators
@@ -281,6 +314,25 @@ function partial_op_and_grads_and_hessians!(
     return partial_op_and_grads_and_hessians!(y, Dy, H, op, x, outputs)
 end
 
+# The safe-guarded methods can now simply forward to the parametric versions 
+# and pass `nothing` parameters:
+function func_vals!(y, op::AbstractNonlinearOperator, x; outputs=nothing)
+    return func_vals!(y, op, x, nothing; outputs)
+end
+function func_grads!(Dy, op::AbstractNonlinearOperator, x; outputs=nothing)
+    return func_grads!(Dy, op, x, nothing; outputs)
+end
+function func_vals_and_grads!(y, Dy, op::AbstractNonlinearOperator, x; outputs=nothing)
+    return func_vals_and_grads!(y, Dy, op, x, nothing; outputs)
+end
+function func_hessians!(H, op::AbstractNonlinearOperator, x; outputs=nothing)
+    return func_hessians!(H, op, x, nothing; outputs)
+end
+function func_vals_and_grads_and_hessians!(
+    y, Dy, H, op::AbstractNonlinearOperator, x; outputs=nothing
+)
+    return func_vals_and_grads_and_hessians!(y, Dy, H, op, x, nothing; outputs)
+end
 # #### Non-Parametric Methods for Parametric Operators
 # These should only be used when you know what you are doing, as we set the parameters
 # to `nothing`.
@@ -479,6 +531,7 @@ export AbstractSurrogateModel, AbstractSurrogateModelConfig
 export supports_partial_evaluation, provides_grads, provides_hessians, requires_grads, requires_hessians
 export func_vals!, func_grads!, func_hessians!, func_vals_and_grads!, func_vals_and_grads_and_hessians!
 export eval_op!, eval_grads!, eval_hessians!, eval_op_and_grads!, eval_op_and_grads_and_hessians!
+export func_vals!, func_grads!, func_vals_and_grads!, func_vals_and_grads_and_hessians!
 export model_op!, model_grads!, model_op_and_grads!
 export init_surrogate, update!
 

--- a/src/affine_scalers.jl
+++ b/src/affine_scalers.jl
@@ -42,12 +42,14 @@ unscale!(ξ::Nothing, scaler::AbstractAffineScaler, x::Nothing) = nothing
 end
 scale_eq!(::Nothing, scaler::AbstractAffineScaler, ::Nothing)=nothing
 
-struct IdentityScaler <: AbstractConstantAffineScaler end
+struct IdentityScaler <: AbstractConstantAffineScaler 
+    dim :: Int
+end
 
 scale!(x::RVec, scaler::IdentityScaler, ξ::RVec)=copyto!(x, ξ)
 unscale!(ξ::RVec, scaler::IdentityScaler, x::RVec)=copyto!(ξ, x)
-scaling_matrix(scaler::IdentityScaler) = LA.I(length(ξ))
-unscaling_matrix(scaler::IdentityScaler) = LA.I(length(x))
+scaling_matrix(scaler::IdentityScaler) = LA.I(scaler.dim)
+unscaling_matrix(scaler::IdentityScaler) = LA.I(scaler.dim)
 
 ## ξ = Tx + b
 ## x = T⁻¹(ξ - b) = T⁻¹ξ - T⁻¹b
@@ -65,10 +67,10 @@ unscaling_matrix(scaler::AffineVarScaler)=scaler.Tinv
 scaling_offset(scaler::AffineVarScaler)=scaler.b
 unscaling_offset(scaler::AffineVarScaler)=scaler.binv
 
-init_box_scaler(lb, ub)=IdentityScaler()
-function init_box_scaler(lb::RVec, ub::RVec)
+init_box_scaler(lb, ub, dim)=IdentityScaler(dim)
+function init_box_scaler(lb::RVec, ub::RVec, dim)
     if any(isinf.(lb)) || any(isinf.(ub))
-        return init_box_scaler(nothing, nothing)
+        return init_box_scaler(nothing, nothing, dim)
     end
 
     ## set up a min-max scaler

--- a/src/evaluators/ExactModels.jl
+++ b/src/evaluators/ExactModels.jl
@@ -2,6 +2,7 @@ module ExactModels
 
 using ..Compromise.CompromiseEvaluators
 const CE = CompromiseEvaluators
+import Compromise: @serve
 
 Base.@kwdef struct ExactModel{O,P} <: AbstractSurrogateModel#{O<:AbstractNonlinearOperator, P}
     op :: O
@@ -19,16 +20,30 @@ function CE.init_surrogate(::ExactModelConfig, op, dim_in, dim_out, params, T)
 end
 
 function CE.model_op!(y, surr::ExactModel, x)
-    eval_op!(y, surr.op, x, surr.params)
+    #eval_op!(y, surr.op, x, surr.params)
+    # if `surr.op` has enforce_max_calls==true then func_vals checks for max_calls
+    # if it does not, we could/should do it here...
+    @serve CE.check_num_calls(surr.op, 1; force=true)
+    return func_vals!(y, surr.op, x, surr.params)
 end
 function CE.model_grads!(Dy, surr::ExactModel, x)
-    return eval_grads!(Dy, surr.op, x, surr.params)
+    #return eval_grads!(Dy, surr.op, x, surr.params)
+    @serve CE.check_num_calls(surr.op, 2; force=true)
+    return func_grads!(Dy, surr.op, x, surr.params)
 end
 function CE.model_op_and_grads!(y, Dy, surr::ExactModel, x)
-    return eval_op_and_grads!(y, Dy, surr.op, x, surr.params)
+    #return eval_op_and_grads!(y, Dy, surr.op, x, surr.params)
+    @serve CE.check_num_calls(surr.op, (1,2); force=true)
+    return func_vals_and_grads!(y, Dy, surr.op, x, surr.params)
 end
 CE.supports_partial_evaluation(::ExactModel)=false
 
+function CE.update!(
+    surr::ExactModel, op, Δ, x, fx, lb, ub; kwargs...
+)
+    #src return CE.check_num_calls(op, (1,2)) #TODO think about this
+    return nothing
+end
 #=
 CE.copy_model(mod::ExactModel)=mod
 CE.copyto_model!(mod_trgt::ExactModel, mod_src::ExactModel)=mod_trgt

--- a/src/evaluators/NonlinearFunctions.jl
+++ b/src/evaluators/NonlinearFunctions.jl
@@ -62,11 +62,21 @@ compute the derivatives if the relevant field `isnothing`.
     func_and_grads_and_hessians :: FGH = nothing
     backend :: B = NoBackend()
 
-    func_iip :: Bool = true # true -> func!(y, x, p), false -> y = func(x, p)
-    grads_iip :: Bool = true # true -> grads!(Dy, x, p), false -> Dy = grads(x, p)
-    hessians_iip :: Bool = true # true -> hessians!(H, x, p), false -> H = hessians(x, p)
+    func_iip :: Bool = false # true -> func!(y, x, p), false -> y = func(x, p)
+    grads_iip :: Bool = false # true -> grads!(Dy, x, p), false -> Dy = grads(x, p)
+    hessians_iip :: Bool = false # true -> hessians!(H, x, p), false -> H = hessians(x, p)
     func_and_grads_iip :: Bool = grads_iip  # true -> func_and_grads!(y, Dy, x, p), false -> y, Dy = func_and_grads(x, p)
     func_and_grads_and_hessians_iip :: Bool = hessians_iip # true -> func_and_grads_and_hessians!(y, Dy, H, x, p), false -> y, Dy, H = func_and_grads_and_hessians(x, p)
+
+    num_func_calls :: Base.RefValue{Int} = Ref(0)
+    num_grad_calls :: Base.RefValue{Int} = Ref(0)
+    num_hess_calls :: Base.RefValue{Int} = Ref(0)
+
+    max_func_calls :: Union{Int, Nothing} = nothing
+    max_grad_calls :: Union{Int, Nothing} = nothing
+    max_hess_calls :: Union{Int, Nothing} = nothing
+
+    enforce_max_calls :: Bool = true
 end
 
 function CE.provides_grads(op::NonlinearParametricFunction)
@@ -77,12 +87,38 @@ function CE.provides_hessians(op::NonlinearParametricFunction)
         !(op.backend isa NoBackend)
 end
 
+CE.is_counted(::Nothing)=false
+CE.is_counted(op::NonlinearParametricFunction)=true
+function CE.num_calls(op::NonlinearParametricFunction)
+    return (
+        op.num_func_calls[],
+        op.num_grad_calls[],
+        op.num_hess_calls[]
+    )
+end
+function CE.set_num_calls!(op::NonlinearParametricFunction, vals::Tuple{Int,Int,Int})
+    op.num_func_calls[]=0
+    op.num_grad_calls[]=0
+    op.num_hess_calls[]=0
+    return nothing
+end
+function CE.max_calls(op::NonlinearParametricFunction)
+    return (
+        op.max_func_calls,
+        op.max_grad_calls,
+        op.max_hess_calls
+    )
+end
+
+CE.enforce_max_calls(op::NonlinearParametricFunction)=op.enforce_max_calls
+
 function CE.eval_op!(y, op::NonlinearParametricFunction, x, p)
     if op.func_iip 
         op.func(y, x, p)
     else
         y .= op.func(x, p)
     end
+    op.num_func_calls[]+=1
     return nothing
 end
 
@@ -105,6 +141,7 @@ function CE.eval_grads!(Dy, op::NonlinearParametricFunction, x, p)
     else
         ad_grads!(Dy, op.backend, op.func, x, p, Val(op.func_iip))
     end
+    op.num_grad_calls[]+=1
     return nothing
 end
 
@@ -129,9 +166,14 @@ function CE.eval_hessians!(H, op::NonlinearParametricFunction, x, p)
     else
         ad_hessians!(H, op.backend, op.func, x, p, Val(op.func_iip))
     end
+
+    op.num_hess_calls[]+=1
+
+    return nothing
 end
 
 function CE.eval_op_and_grads!(y, Dy, op::NonlinearParametricFunction, x, p)
+    inc_counter = false
     if !isnothing(op.func_and_grads)
         if op.func_and_grads_iip
             op.func_and_grads(y, Dy, x, p)
@@ -141,16 +183,24 @@ function CE.eval_op_and_grads!(y, Dy, op::NonlinearParametricFunction, x, p)
             y .= _y
             Dy .= _Dy
         end
+        inc_counter = true
     elseif !isnothing(op.grads)
         eval_op!(y, op, x, p)
         eval_grads!(Dy, op, x, p)
     else
         ad_op_and_grads!(y, Dy, op.backend, op.func, x, p, Val(op.func_iip))
+        inc_counter = true
+    end
+    
+    if inc_counter
+        op.num_func_calls[]+=1
+        op.num_grad_calls[]+=1
     end
     return nothing
 end
 
 function CE.eval_op_and_grads_and_hessians!(y, Dy, H, op::NonlinearParametricFunction, x, p)
+    inc_couter = false
     if !isnothing(op.func_and_grads_and_hessians)
         if op.func_and_grads_and_hessians_iip
             op.func_and_grads_and_hessians(y, Dy, H, x, p)
@@ -161,12 +211,21 @@ function CE.eval_op_and_grads_and_hessians!(y, Dy, H, op::NonlinearParametricFun
             Dy .= _Dy
             H .= _H
         end
+        inc_couter = true
     elseif !isnothing(op.hessians)
         eval_op_and_grads!(y, Dy, op, x, p)
         eval_hessians!(H, op, x, p)
     else
         ad_op_and_grads_and_hessians!(y, Dy, H, op.backend, op.func, x, p, Val(op.func_iip))
+        inc_couter = true
     end
+
+    if inc_couter
+        op.num_func_calls[]+=1
+        op.num_grad_calls[]+=1
+        op.num_hess_calls[]+=1
+    end
+    
     return nothing
 end
 
@@ -257,6 +316,11 @@ macro forward(call_ex)
 end
 
 @forward CE.supports_partial_evaluation(op::NonlinearFunction)
+@forward CE.is_counted(op::NonlinearFunction)
+@forward CE.num_calls(op::NonlinearFunction)
+@forward CE.max_calls(op::NonlinearFunction)
+@forward CE.enforce_max_calls(op::NonlinearFunction)
+@forward CE.set_num_calls!(op::NonlinearFunction)
 @forward CE.provides_grads(op::NonlinearFunction)
 @forward CE.provides_hessians(op::NonlinearFunction)
 @forward CE.eval_op!(y, op::NonlinearFunction, x)
@@ -264,6 +328,11 @@ end
 @forward CE.eval_hessians!(H, op::NonlinearFunction, x)
 @forward CE.eval_op_and_grads!(y, Dy, op::NonlinearFunction, x)
 @forward CE.eval_op_and_grads_and_hessians!(y, Dy, H, op::NonlinearFunction, x)
+@forward CE.func_vals!(y, op::NonlinearFunction, x; outputs=nothing)
+@forward CE.func_grads!(Dy, op::NonlinearFunction, x; outputs=nothing)
+@forward CE.func_vals_and_grads!(y, Dy, op::NonlinearFunction, x; outputs=nothing)
+@forward CE.func_hessians!(H, op::NonlinearFunction, x; outputs=nothing)
+@forward CE.func_vals_and_grads_and_hessians!(y, Dy, H, op::NonlinearFunction, x; outputs=nothing)
 
 export AbstractAutoDiffBackend, NoBackend
 export ad_grads!, ad_hessians!, ad_op_and_grads!, ad_op_and_grads_and_hessians!

--- a/src/evaluators/NonlinearFunctions.jl
+++ b/src/evaluators/NonlinearFunctions.jl
@@ -206,7 +206,7 @@ function CE.eval_op_and_grads_and_hessians!(y, Dy, H, op::NonlinearParametricFun
             op.func_and_grads_and_hessians(y, Dy, H, x, p)
         else
             @debug "Allocating temporary output arrays for `eval_op_and_grads_and_hessians!`."
-            _y, _Dy, _H = op.func_and_grads(x, p)
+            _y, _Dy, _H = op.func_and_grads_and_hessians(x, p)
             y .= _y
             Dy .= _Dy
             H .= _H

--- a/src/evaluators/TaylorPolynomialModels.jl
+++ b/src/evaluators/TaylorPolynomialModels.jl
@@ -108,7 +108,7 @@ function CE.model_grads!(Dy, tp::TaylorPolynomial2, x)
     @views for i = axes(H, 3)
         ## (assuming symmetric Hessians here)
         Hi = H[:, :, i]
-        LA.mul!(Dy[:, i], Hi, Δx, 2, 1)   
+        LA.mul!(Dy[:, i], Hi, Δx, 1, 1)   
     end
     return nothing
 end
@@ -131,14 +131,13 @@ function CE.model_op_and_grads!(y, Dy, tp::TaylorPolynomial2, x)
     HΔx = tp.xtmp
     @views for i = axes(H, 3)
         Hi = H[:, :, i]
-        LA.mul!(HΔx, Hi, Δx, 0.5, 0)
+        LA.mul!(HΔx, Hi, Δx, 1, 0)
 
         ## 1) add Hessian term to value `y[i]`
-        y[i] += Δx'HΔx
+        y[i] += 0.5 * Δx'HΔx
 
         ## 2) add Hessian terms to gradients `Dy[:, i]`
         ## (assuming symmetric Hessians here)
-        HΔx .*= 4
         Dy[:, i] .+= HΔx
     end
 
@@ -147,7 +146,7 @@ end
 
 function CE.update!(tp::TaylorPolynomial1, op, Δ, x, fx, lb, ub; kwargs...)
     if tp.x0 != x || any(isnan.(tp.x0))
-        @serve CE.check_num_calls(op, 1; force=true)
+        @serve CE.check_num_calls(op, (1,2); force=true)
         copyto!(tp.x0, x)
         #src eval_op_and_grads!(tp.fx, tp.Dfx, op, x)
         func_vals_and_grads!(tp.fx, tp.Dfx, op, x)
@@ -157,7 +156,7 @@ end
 function CE.update!(tp::TaylorPolynomial2, op, Δ, x, fx, lb, ub; kwargs...)
     tp1 = tp.tp
     if tp1.x0 != x || any(isnan.(tp1.x0))
-        @serve CE.check_num_calls(op, (1,2); force=true)
+        @serve CE.check_num_calls(op, (1,2,3); force=true)
         copyto!(tp1.x0, x)
         #src eval_op_and_grads_and_hessians!(tp1.fx, tp1.Dfx, tp.Hfx, op, x)
         func_vals_and_grads_and_hessians!(tp1.fx, tp1.Dfx, tp.Hfx, op, x)

--- a/src/evaluators/TaylorPolynomialModels.jl
+++ b/src/evaluators/TaylorPolynomialModels.jl
@@ -5,6 +5,8 @@ using Parameters: @with_kw
 using ..Compromise.CompromiseEvaluators
 const CE = CompromiseEvaluators
 
+import ..Compromise: @serve
+
 struct TaylorPolynomial1{
     X <: AbstractVector{<:Real},
     F <: AbstractVector{<:Real},
@@ -145,16 +147,20 @@ end
 
 function CE.update!(tp::TaylorPolynomial1, op, Δ, x, fx, lb, ub; kwargs...)
     if tp.x0 != x || any(isnan.(tp.x0))
+        @serve CE.check_num_calls(op, 1; force=true)
         copyto!(tp.x0, x)
-        eval_op_and_grads!(tp.fx, tp.Dfx, op, x)
+        #src eval_op_and_grads!(tp.fx, tp.Dfx, op, x)
+        func_vals_and_grads!(tp.fx, tp.Dfx, op, x)
     end
 end
 
 function CE.update!(tp::TaylorPolynomial2, op, Δ, x, fx, lb, ub; kwargs...)
-    if tp.x0 != x || any(isnan.(tp.x0))
-        tp1 = tp.tp
+    tp1 = tp.tp
+    if tp1.x0 != x || any(isnan.(tp1.x0))
+        @serve CE.check_num_calls(op, (1,2); force=true)
         copyto!(tp1.x0, x)
-        eval_op_and_grads_and_hessians!(tp1.fx, tp1.Dfx, tp.Hfx, op, x)
+        #src eval_op_and_grads_and_hessians!(tp1.fx, tp1.Dfx, tp.Hfx, op, x)
+        func_vals_and_grads_and_hessians!(tp1.fx, tp1.Dfx, tp.Hfx, op, x)
     end
     return nothing
 end

--- a/src/mop.jl
+++ b/src/mop.jl
@@ -77,6 +77,12 @@ dim_lin_eq_constraints(mop::AbstractMOP)=dim_lin_constraints(lin_eq_constraints(
 dim_lin_ineq_constraints(mop::AbstractMOP)=dim_lin_constraints(lin_ineq_constraints(mop))
 
 # ## Evaluation
+
+# !!! note
+#     All evaluation and differentiation methods that you see below should always 
+#     return `nothing`, **unless** you want to stop early.
+#     Then return something else, for example a string.
+
 # Evaluation of nonlinear objective functions requires the following method:
 function eval_objectives!(y::RVec, mop::M, x::RVec) where {M<:AbstractMOP}
     error("`eval_objectives!(y, mop, x) not implemented for mop of type $(M).")

--- a/src/restoration.jl
+++ b/src/restoration.jl
@@ -41,8 +41,10 @@ function restoration_objective(mop, scaler, scaled_cons)
 
         ξr = similar(xr)
         unscale!(ξr, scaler, xr)
-        nl_eq_constraints!(hx, mop, ξr)
-        nl_ineq_constraints!(gx, mop, ξr)
+        r_eq = nl_eq_constraints!(hx, mop, ξr)
+        !isnothing(r_eq) && error(string(r_eq))
+        r_ineq = nl_ineq_constraints!(gx, mop, ξr)
+        !isnothing(r_ineq) && error(string(r_ineq))
         lin_cons!(Eres, Ex, scaled_cons.A_b, xr)
         lin_cons!(Ares, Ax, scaled_cons.E_c, xr)
         
@@ -84,7 +86,8 @@ function postproccess_restoration(
     ##  we have to set `vals` eventually. in case of unsuccessfull restoration, we have to 
     ##  abort anyways)
     copyto!(vals.x, xr_opt)
-    eval_mop!(vals, mop, scaler)
+    mop_code = eval_mop!(vals, mop, scaler)
+    !isnothing(mop_code) && return GenericStopping(mop_code, algo_opts.log_level)
 
     Δ = iter_meta.Δ_pre
 

--- a/src/stopping.jl
+++ b/src/stopping.jl
@@ -192,3 +192,13 @@ function evaluate_stopping_criterion(
 end
 
 struct InfeasibleStopping <: AbstractStoppingCriterion end
+
+struct GenericStopping{F} <: AbstractStoppingCriterion 
+    ret :: F
+end
+
+function GenericStopping(ret, log_level)
+    @logmsg log_level "$(ret)"
+    return GenericStopping(ret)
+end
+

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -9,7 +9,7 @@ function test_trial_point!(
     
     # Use `vals_tmp` to hold the true values at `xs`:
     copyto!(vals_tmp.x, xs)
-    eval_mop!(vals_tmp, mop, scaler)
+    @serve eval_mop!(vals_tmp, mop, scaler)
 
     # To test the trial point against the filter, extract
     # current values and trial point values
@@ -70,5 +70,5 @@ function test_trial_point!(
     iter_meta.vals_diff_len = LA.norm(iter_meta.vals_diff_vec)
     iter_meta.mod_vals_diff_len = LA.norm(iter_meta.mod_vals_diff_vec)
 
-    return iter_meta.it_stat_post
+    return nothing
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -169,14 +169,17 @@ struct StepValueArrays{T}
 	s :: Vector{T}
     xs :: Vector{T}
     fxs :: Vector{T}
+	crit_ref :: Base.RefValue{T}
 end
 
 function Base.copyto!(step_vals_trgt::StepValueArrays, step_vals_src::StepValueArrays)
 	for fn in fieldnames(StepValueArrays)
+		fn == :crit_ref && continue
 		trgt_fn = getfield(step_vals_trgt, fn)
 		isnothing(trgt_fn) && continue
 		copyto!(trgt_fn, getfield(step_vals_src, fn))
 	end
+	step_vals_trgt.crit_ref[] = step_vals_src.crit_ref[]
 	return nothing
 end
 
@@ -190,7 +193,8 @@ function StepValueArrays(x, fx)
         zeros(T, nin),
         zeros(T, nin),
         zeros(T, nin),
-        zeros(T, nout)
+        zeros(T, nout),
+		Ref(T(Inf))
     )
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,3 +13,22 @@ end
 
 promote_modulo_nothing(T1, ::Type{Nothing})=T1
 promote_modulo_nothing(T1, T2)=Base.promote_type(T1, eltype(T2))
+macro serve(ex)
+	ret_val = gensym()
+	return quote
+		$(ret_val) = $(ex)
+		if !isnothing($(ret_val))
+			return $(ret_val)
+		end
+	end |> esc
+end
+
+macro exit(ex)
+	ret_val = gensym()
+	return quote
+		$(ret_val) = $(ex)
+		if !isnothing($(ret_val))
+			break
+		end
+	end |> esc
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ using Test
         
         return mop
     end
-
+    
     #%%
     mop = setup_mop()
     final_vals, stop_code = optimize(
@@ -181,4 +181,170 @@ using Test
         user_callback = MyCallback()
     )
     @test stop_code isa MyCallback
+end
+
+@testset "Max Eval Stopping" begin
+
+    algo_opts = AlgorithmOptions(;
+        max_iter=typemax(Int),
+        stop_delta_min=-Inf,
+        stop_xtol_rel=-Inf,
+        stop_xtol_abs=-Inf,
+        stop_ftol_rel=-Inf,
+        stop_ftol_abs=-Inf,
+        stop_crit_tol_abs=-Inf,
+        stop_theta_tol_abs=-Inf,
+        stop_max_crit_loops=typemax(Int)
+    )
+
+    fn_counter = Ref(0)
+    dfn_counter = Ref(0)
+
+    function objective_function(x)
+        fn_counter[] += 1
+        return [
+            sum( (x .- 1).^2 ),
+            sum( (x .+ 1).^2 ),
+        ]
+    end
+
+    function grads_objectives_function(x)
+        dfn_counter[] += 1
+        return 2 .* hcat( x .- 1, x .+ 1 )
+    end
+
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :exact; 
+        dim_out=2, max_func_calls=10, enforce_max_calls=true
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+
+    @test fn_counter[] == 10
+    @test stop_code isa Compromise.GenericStopping
+    @test stop_code.ret == "Maximum evaluation count reached, order=0, evals 10 >= 10."
+
+    fn_counter[] = 0
+    dfn_counter[] = 0
+    
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :exact; 
+        dim_out=2, max_grad_calls=1, enforce_max_calls=true
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+    @test dfn_counter[] == 1
+    @test stop_code isa Compromise.GenericStopping
+    @test stop_code.ret == "Maximum evaluation count reached, order=1, evals 1 >= 1."
+
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :exact; 
+        dim_out=2, max_grad_calls=1, enforce_max_calls=true
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+    @test dfn_counter[] == 2
+    @test stop_code isa Compromise.GenericStopping
+    @test stop_code.ret == "Maximum evaluation count reached, order=1, evals 1 >= 1."
+
+    fn_counter[] = 0
+    dfn_counter[] = 0
+    
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :exact; 
+        dim_out=2, max_func_calls=100, enforce_max_calls=false
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+
+    @test fn_counter[] == 100
+    @test stop_code isa Compromise.GenericStopping
+    @test stop_code.ret == "Maximum evaluation count reached, order=0, evals 100 >= 100."
+
+    fn_counter[] = 0
+    dfn_counter[] = 0
+    
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :rbf; 
+        dim_out=2, max_func_calls=10, enforce_max_calls=false
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+    @test fn_counter[] == 10
+    @test stop_code isa Compromise.GenericStopping
+    @test stop_code.ret == "RBF Training: No sampling budget. Aborting."
+
+    fn_counter[] = 0
+    dfn_counter[] = 0
+    
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :rbf; 
+        dim_out=2, max_func_calls=10, enforce_max_calls=true
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+    @test fn_counter[] == 10
+    @test stop_code isa Compromise.GenericStopping
+
+    fn_counter[] = 0
+    dfn_counter[] = 0
+    
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :taylor1; 
+        dim_out=2, max_func_calls=10, enforce_max_calls=true
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+    @test fn_counter[] == 10
+    @test stop_code isa Compromise.GenericStopping
+
+    fn_counter[] = 0
+    dfn_counter[] = 0
+    
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :taylor1; 
+        dim_out=2, max_func_calls=10, enforce_max_calls=false
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+    @test fn_counter[] == 10
+    @test stop_code isa Compromise.GenericStopping
+
+    
+    function hess_objectives_function(x)
+        n = length(x)
+        H = zeros(eltype(x), n, n, 2)
+        for l in [1,2]
+            for i=1:n
+                H[i, i, l] = 2
+            end
+        end
+        return H
+    end
+    
+    fn_counter[] = 0
+    dfn_counter[] = 0
+
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, :taylor2; 
+        dim_out=2, max_func_calls=10, enforce_max_calls=true,
+        hessians=hess_objectives_function, hessians_iip=false 
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+    @test fn_counter[] == 10
+    @test stop_code isa Compromise.GenericStopping
+
+    fn_counter[] = 0
+    dfn_counter[] = 0
+    
+    mop = MutableMOP(;num_vars=2)
+    add_objectives!(
+        mop, objective_function, grads_objectives_function, hess_objectives_function, :taylor2; 
+        dim_out=2, max_func_calls=10, enforce_max_calls=false,
+        hessians=hess_objectives_function, hessians_iip=false
+    )
+    final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
+    @test_broken fn_counter[] == 10
+    @test stop_code isa Compromise.GenericStopping
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,69 @@
 using Compromise
 using Test
 
+@testset "Taylor Polynomials deg 2" begin
+    tcfg = TaylorPolynomialConfig(;degree=2)
+    function func(x)
+        return [
+            sum( (x .- 1).^2 ),
+            sum( (x .+ 1).^2 ),
+        ]
+    end
+
+    function grads(x)
+        return 2 .* hcat( x .- 1, x .+ 1 )
+    end
+
+    function hessians(x)
+        n = length(x)
+        H = zeros(eltype(x), n, n, 2)
+        for l in [1,2]
+            for i=1:n
+                H[i, i, l] = 2
+            end
+        end
+        return H
+    end
+
+    op = Compromise.NonlinearFunction(;func, grads, hessians)
+    tp = Compromise.init_surrogate(tcfg, op, 2, 2, nothing, Float64)
+
+    x = rand(2)
+    y = zeros(2)
+    Compromise.eval_op!(y, op, x)
+    Compromise.update!(tp, op, nothing, x, y, nothing, nothing)
+    z = zeros(2)
+    Compromise.model_op!(z, tp, x)
+
+    @test y == z
+
+    Dy = zeros(2,2)
+    Compromise.model_grads!(Dy, tp, x)
+    @test Dy == grads(x)
+
+    Dy .= 0
+    y .= 0
+    Compromise.model_op_and_grads!(y, Dy, tp, x)
+    @test y == func(x)
+    @test Dy == grads(x)
+
+    Hy = zeros(2,2,2)
+    Dy .= 0
+    y .= 0
+    Compromise.eval_op_and_grads_and_hessians!(y, Dy, Hy, op, x)
+    @test y == func(x)
+    @test Dy == grads(x)
+    @test Hy == hessians(x)
+
+    Hy = zeros(2,2,2)
+    Dy .= 0
+    y .= 0
+    Compromise.func_vals_and_grads_and_hessians!(y, Dy, Hy, op, x)
+    @test y == func(x)
+    @test Dy == grads(x)
+    @test Hy == hessians(x)
+end
+
 @testset "Stopping Criteria" begin
     function setup_mop()
         mop = MutableMOP(;num_vars=2)
@@ -213,6 +276,17 @@ end
         return 2 .* hcat( x .- 1, x .+ 1 )
     end
 
+    function hess_objectives_function(x)
+        n = length(x)
+        H = zeros(eltype(x), n, n, 2)
+        for l in [1,2]
+            for i=1:n
+                H[i, i, l] = 2
+            end
+        end
+        return H
+    end
+
     mop = MutableMOP(;num_vars=2)
     add_objectives!(
         mop, objective_function, grads_objectives_function, :exact; 
@@ -309,18 +383,6 @@ end
     final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
     @test fn_counter[] == 10
     @test stop_code isa Compromise.GenericStopping
-
-    
-    function hess_objectives_function(x)
-        n = length(x)
-        H = zeros(eltype(x), n, n, 2)
-        for l in [1,2]
-            for i=1:n
-                H[i, i, l] = 2
-            end
-        end
-        return H
-    end
     
     fn_counter[] = 0
     dfn_counter[] = 0
@@ -340,11 +402,11 @@ end
     
     mop = MutableMOP(;num_vars=2)
     add_objectives!(
-        mop, objective_function, grads_objectives_function, hess_objectives_function, :taylor2; 
+        mop, objective_function, grads_objectives_function, :taylor2; 
         dim_out=2, max_func_calls=10, enforce_max_calls=false,
         hessians=hess_objectives_function, hessians_iip=false
     )
     final_vals, stop_code = optimize(mop, [π, -ℯ]; algo_opts)
-    @test_broken fn_counter[] == 10
+    @test fn_counter[] == 10
     @test stop_code isa Compromise.GenericStopping
 end


### PR DESCRIPTION
This pull enables more stopping criteria at various points in the algorithm.

The model update methods and step calculation methods are in-place and usually return `nothing`. To stop optimization, we can return something else.
Most of the time this immediately returns a `GenericStopping` code and logs a message.

There are some few tests for capping the number of function evaluations.
We can and should capping the number of derivative evaluations.

Also fix an error for taylor2 models.