### PR TITLE
fix docs by disabling errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.9'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,6 +51,7 @@ makedocs(;
         "(Dev) Notes" => "dev_notes.md",
         "Interfaces" => ["CompromiseEvaluators.md", "mop.md", "models.md"],
     ],
+    warnonly = true, # TODO be more strict about this
 )
 
 deploydocs(;

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,5 +1,5 @@
 ```@meta
-EditURL = "<unknown>/docs/literate_src/README.jl"
+EditURL = "../literate_src/README.jl"
 ```
 
 # Compromise.jl

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,5 +12,5 @@ Random Doc-Strings:
 ```
 
 ```@autodocs
-Modules = [Compromise]
+Modules = [Compromise.NonlinearFunctions, Compromise,]
 ```

--- a/src/Compromise.jl
+++ b/src/Compromise.jl
@@ -57,7 +57,7 @@ const CE = CompromiseEvaluators
 # Import wrapper types to make user-provided functions conform to the operator interface:
 include("evaluators/NonlinearFunctions.jl")
 using .NonlinearFunctions
-
+import .NonlinearFunctions: NonlinearParametricFunction
 # Import the optional extension `ForwardDiffBackendExt`, if `ForwardDiff` is available:
 
 using Requires

--- a/src/evaluators/NonlinearFunctions.jl
+++ b/src/evaluators/NonlinearFunctions.jl
@@ -24,7 +24,7 @@ using Parameters: @with_kw
 
 # ## Wrapper for Parametric Functions
 
-"""
+@doc """
     NonlinearParametricFunction(; 
         func, grads=nothing, hessians=nothing, 
         func_and_grads=nothing, func_and_grads_and_hessians=nothing,
@@ -53,7 +53,6 @@ flags indicate the following signatures:
 Alternatively (or additionally), an `AbstractAutoDiffBackend` can be passed to 
 compute the derivatives if the relevant field `isnothing`.
 """
-
 @with_kw struct NonlinearParametricFunction{F, G, H, FG, FGH, B} <: AbstractNonlinearOperatorWithParams
     func :: F
     grads :: G = nothing

--- a/src/evaluators/RBFModels.jl
+++ b/src/evaluators/RBFModels.jl
@@ -2,7 +2,7 @@ module RBFModels
 
 using ..Compromise.CompromiseEvaluators
 const CE = CompromiseEvaluators
-import ..Compromise: @serve
+import ..Compromise: @serve, DEFAULT_PRECISION
 
 using ElasticArrays
 import LinearAlgebra as LA
@@ -297,7 +297,9 @@ function intersect_intervals(l1, r1, l2, r2, T=typeof(l1))
 end
 
 function intersect_box(x::X, z::Z, lb::L, ub::U) where {X, Z, L, U}
-    T = Base.promote_eltype(X, Z, L, U)
+    _T = Base.promote_eltype(X, Z, L, U)
+    T = _T <: AbstractFloat ? _T : DEFAULT_PRECISION
+
     σ_min, σ_max = T(-Inf), T(Inf)
     for (xi, zi, lbi, ubi) = zip(x, z, lb, ub)    
         ## x + σ * z <= ub

--- a/src/simple_mop.jl
+++ b/src/simple_mop.jl
@@ -276,7 +276,7 @@ for (fntype, typenoun) in (
         Keyword argument `dim_out` is mandatory and corresponds to the length of the result
         vector.
         The other `kwargs...` are passed to the inner `AbstractNonlinearOperator` as is.
-        For options and defaults see [`Compromise.NonlinearParametricFunction`](@ref).
+        For options and defaults see [`NonlinearParametricFunction`](@ref).
         """
         function $(add_fn)(
             mop::MutableMOP, func::Function, model_cfg=nothing; dim_out::Int, kwargs...
@@ -304,7 +304,7 @@ for (fntype, typenoun) in (
         Keyword argument `dim_out` is mandatory and corresponds to the length of the result
         vector.
         The other `kwargs...` are passed to the inner `AbstractNonlinearOperator` as is.
-        For options and defaults see [`Compromise.NonlinearParametricFunction`](@ref).
+        For options and defaults see [`NonlinearParametricFunction`](@ref).
         """
         function $(add_fn)(
             mop::MutableMOP, func::Function, grads::Function, model_cfg=nothing; dim_out::Int, kwargs...
@@ -329,7 +329,7 @@ for (fntype, typenoun) in (
         Keyword argument `dim_out` is mandatory and corresponds to the length of the result
         vector.
         The other `kwargs...` are passed to the inner `AbstractNonlinearOperator` as is.
-        For options and defaults see [`Compromise.NonlinearParametricFunction`](@ref).
+        For options and defaults see [`NonlinearParametricFunction`](@ref).
         """
         function $(add_fn)(
             mop::MutableMOP, func::Function, grads::Function, func_and_grads::Function, 


### PR DESCRIPTION
New Documenter versions are very strict about errors. For now, we emulate the old non-strict behavior.
I also increased the docs CI version to 1.9.