### PR TITLE
batch scaling

### DIFF
--- a/docs/src/CompromiseEvaluators.md
+++ b/docs/src/CompromiseEvaluators.md
@@ -31,7 +31,7 @@ abstract type AbstractNonlinearOperatorNoParams <: AbstractNonlinearOperator end
 operator_has_name(::AbstractNonlinearOperator)::Bool=false
 operator_name(::AbstractNonlinearOperator)=error("No name.")
 
-operator_can_eval_multi(::AbstractNonlinearOperator)::Bool=false
+operator_chunk_size(::AbstractNonlinearOperator)::Integer=1
 operator_has_params(::AbstractNonlinearOperator)::Bool=false
 operator_can_partial(::AbstractNonlinearOperator)::Bool=false
 
@@ -337,13 +337,25 @@ function func_vals!(
         _Y = Y
     end
 
-    if operator_can_eval_multi(op)
+    cs = operator_chunk_size(op)
+    if 1 < cs <= N
         @ignoraise redirect_call(eval_op!, op, _X, params, outputs, _Y)
     else
+        i_start = 1
+        i_end = 0
+        while i_end < N
+            i_end = min(i_start + cs - 1, N)
+            y = @view(_Y[:, i_start:i_end])
+            x = @view(_X[:, i_start:i_end])
+            @ignoraise redirect_call(eval_op!, op, x, params, outputs, y)
+            i_start = i_end + 1
+        end
+        #=
         for (y, x) = zip(eachcol(_Y), eachcol(_X))
             @ignoraise redirect_call(eval_op!, op, x, params, outputs, y)
             #@ignoraise func_vals!(y, op, x, params, outputs)
         end
+        =#
     end
     return nothing
 end
@@ -401,7 +413,7 @@ to be fix in-between optimization runs.
 abstract type AbstractSurrogateModel <: AbstractNonlinearOperator end
 operator_has_params(::AbstractSurrogateModel)=false
 operator_can_partial(::AbstractSurrogateModel)=false
-operator_can_eval_multi(::AbstractSurrogateModel)=false
+operator_chunk_size(::AbstractSurrogateModel)=1
 
 provides_grads(::AbstractSurrogateModel)=true
 ````

--- a/test/multifunc.jl
+++ b/test/multifunc.jl
@@ -23,7 +23,7 @@ xopt = opt_vars(ret)
 @test !oop_mat_func_called[]
 #%%
 mop = MutableMOP(; num_vars=2)
-add_objectives!(mop, multiobjf, :rbf; dim_out=2, func_iip=false, func_is_multi=true)
+add_objectives!(mop, multiobjf, :rbf; dim_out=2, func_iip=false, chunk_size=Inf)
 
 oop_mat_func_called[] = false
 ret = optimize(mop, [π, -ℯ])
@@ -39,8 +39,11 @@ function multiobjf(y::AbstractVector, x::AbstractVector)
 end
 
 iip_mat_func_called = Ref(false)
+iip_sx = Ref(0)
 function multiobjf(y::AbstractMatrix, x::AbstractMatrix) 
     global iip_mat_func_called[] = true
+    global iip_sx
+    iip_sx[] = max(size(x, 2), iip_sx[])
     map(multiobjf, eachcol(y), eachcol(x))
     nothing
 end
@@ -55,7 +58,7 @@ xopt = opt_vars(ret)
 @test !iip_mat_func_called[]
 #%%
 mop = MutableMOP(; num_vars=2)
-add_objectives!(mop, multiobjf, :rbf; dim_out=2, func_iip=true, func_is_multi=true)
+add_objectives!(mop, multiobjf, :rbf; dim_out=2, func_iip=true, chunk_size=Inf)
 
 iip_mat_func_called[] = false
 ret = optimize(mop, [π, -ℯ]);
@@ -84,10 +87,32 @@ function parallel_objf(x)
 end
 #%%
 mop = MutableMOP(; num_vars=2)
-add_objectives!(mop, parallel_objf, :rbf; dim_out=2, func_iip=false, func_is_multi=true)
+add_objectives!(mop, parallel_objf, :rbf; dim_out=2, func_iip=false, chunk_size=Inf)
 
 was_parallel[] = false
 ret = optimize(mop, [π, -ℯ]);
 xopt = opt_vars(ret)
 @test isapprox(xopt[1], xopt[2]; rtol=1e-4)
 @test was_parallel[] = true
+#%%
+mop = MutableMOP(; num_vars=2, lb = [-4.0, -4.0], ub = [4.0, 4.0])
+
+add_objectives!(mop, multiobjf, :rbf; dim_out=2, func_iip=true, chunk_size=Inf)
+
+iip_sx[] = 0
+iip_mat_func_called[] = false
+ret = optimize(mop, [π, -ℯ]);
+xopt = opt_vars(ret)
+@test isapprox(xopt[1], xopt[2]; rtol=1e-4)
+@test iip_mat_func_called[]
+@test iip_sx[] <= 3
+#%%
+mop = MutableMOP(; num_vars=2, lb = [-4.0, -4.0], ub = [4.0, 4.0])
+
+add_objectives!(mop, multiobjf, :rbf; dim_out=2, func_iip=false, chunk_size=Inf)
+
+oop_mat_func_called[] = false
+ret = optimize(mop, [π, -ℯ]);
+xopt = opt_vars(ret)
+@test isapprox(xopt[1], xopt[2]; rtol=1e-4)
+@test oop_mat_func_called[]


### PR DESCRIPTION
Generalize batch evaluation, remove `operator_can_eval_multi` in favor of `operator_chunk_size`.
Make `ScaledOperator` support batching too.