### PR TITLE
step simplification and restoration fix

### DIFF
--- a/src/criticality_routine.jl
+++ b/src/criticality_routine.jl
@@ -32,7 +32,6 @@ function criticality_routine!(
             # at this point, `step_vals` have a compatible normal step and descent step
             # we sync this in case we cannot find a normal step for smaller radius `Δj`
             universal_copy!(crit_cache.step_vals, step_vals)
-
             @ignorebreak stop_code =  check_stopping_criterion(
                 stop_crits, CheckPreCritLoop(), 
                 mop, mod, scaler, lin_cons, scaled_cons, vals, vals_tmp,

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -40,6 +40,10 @@ function add_to_filter!(filter::StandardFilter, θ, Φ)
     return num_entries(filter)
 end
 
+function add_to_filter!(filter::StandardFilter, cache)
+    return add_to_filter!(filter, cached_theta(cache), cached_Phi(cache))
+end
+
 function is_acceptable(filter::StandardFilter, θ, Φ)
     θmin = filter.min_theta[]
     Φmin = filter.min_phi[]
@@ -70,4 +74,16 @@ function is_acceptable(filter::StandardFilter, θ_test, Φ_test, θ_add, Φ_add)
     else
         return false
     end
+end
+
+function is_filter_acceptable(filter::StandardFilter, cache)
+    return is_acceptable(filter, cached_theta(cache), cached_Phi(cache))
+end
+
+function is_filter_acceptable(filter::StandardFilter, cache_test, cache_add)
+    return is_acceptable(
+        filter, 
+        cached_theta(cache_test), cached_Phi(cache_test),
+        cached_theta(cache_add), cached_Phi(cache_add),
+    )
 end

--- a/src/main_algo.jl
+++ b/src/main_algo.jl
@@ -103,7 +103,6 @@ function do_iteration!(
     x = $(pretty_row_vec(cached_x(vals)))
     fx = $(pretty_row_vec(cached_fx(vals)))
     """
-
     ## The models are valid
     ## - the last iteration was a successfull restoration iteration.
     ## - if the point has not changed and the models do not depend on the radius or  
@@ -139,13 +138,14 @@ function do_iteration!(
     if !n_is_compatible
         ## Try to do a restoration
         @logmsg log_level "* Normal step incompatible. Trying restoration."
-        add_to_filter!(filter, cached_theta(vals), cached_Phi(vals))
+        add_to_filter!(filter, vals)
         @ignoraise do_restoration(
             mop, mod, scaler, lin_cons, scaled_cons, vals, vals_tmp,
             mod_vals, filter, step_vals, step_cache, crit_cache, trial_caches, 
             iteration_status, iteration_scalars, stop_crits,
             algo_opts
         ) indent
+        return nothing
     end
 
     @logmsg log_level "* Computing a descent step."
@@ -197,7 +197,7 @@ function do_iteration!(
 
     ## update filter
     if iteration_status.iteration_type == THETA_STEP
-        add_to_filter!(filter, cached_theta(vals), cached_Phi(vals))
+        add_to_filter!(filter, vals)
     end
    
     if _trial_point_accepted(iteration_status)

--- a/src/restoration.jl
+++ b/src/restoration.jl
@@ -233,7 +233,7 @@ function postproccess_restoration(
     trial_caches.diff_fx_mod .= cached_fx(mod_vals)
 
     ## the next point should be acceptable for the filter:
-    if is_acceptable(filter, cached_theta(vals_tmp), cached_Phi(vals_tmp))
+    if is_filter_acceptable(filter, vals_tmp)
         ## make models valid at `x + r` and set model values
         ## also compute normal step based on models
         @ignoraise update_models!(mod, Δ, scaler, vals_tmp, scaled_cons; log_level, indent)

--- a/src/steps.jl
+++ b/src/steps.jl
@@ -45,8 +45,8 @@ function do_normal_step!(
 
     else
         step_vals.n .= 0
+        step_vals.xn .= cached_x(vals) .+ step_vals.n
     end
-    step_vals.xn .= cached_x(vals) .+ step_vals.n
     nothing
 end
 

--- a/src/trial.jl
+++ b/src/trial.jl
@@ -13,6 +13,7 @@ function test_trial_point!(
     copyto!(cached_x(vals_tmp), step_vals.xs)
     @ignoraise eval_mop!(vals_tmp, mop, scaler) indent
     
+    fits_filter = is_filter_acceptable(filter, vals, vals_tmp)
     (x, fx, θx, Φx, fx_mod, xs, fxs, θxs, Φxs, fxs_mod) = _trial_point_arrays(
         vals, vals_tmp, mod_vals, step_vals)
 
@@ -20,7 +21,7 @@ function test_trial_point!(
     @unpack diff_x, diff_fx, diff_fx_mod = trial_caches
     iteration_type = _test_trial_point!(
         diff_x, diff_fx, diff_fx_mod,
-        filter, x, xs, fx, fxs, fx_mod, fxs_mod, θx, θxs, Φx, Φxs,
+        x, xs, fx, fxs, fx_mod, fxs_mod, θx, fits_filter, 
         strict_acceptance_test, kappa_theta, psi_theta, nu_accept, nu_success;
     )
     _log_trial_results(θxs, Φxs, iteration_type; indent, log_level)
@@ -58,11 +59,9 @@ end
 
 function _test_trial_point!(
     diff_x, diff_fx, diff_fx_mod,
-    filter, x, xs, fx, fxs, fx_mod, fxs_mod, θx, θxs, Φx, Φxs,
+    x, xs, fx, fxs, fx_mod, fxs_mod, θx, fits_filter,
     strict_acceptance_test, kappa_theta, psi_theta, nu_accept, nu_success
 )
-    
-    fits_filter = is_acceptable(filter, θxs, Φxs, θx, Φx)
     
     @. diff_x = x - xs
     @. diff_fx = fx - fxs

--- a/test/ndset.jl
+++ b/test/ndset.jl
@@ -1,0 +1,26 @@
+import Compromise as C
+import Compromise: NondominatedSet, init_nondom_set!
+import Compromise: @unpack
+
+include("TestProblems.jl")
+TP = TestProblems
+#%%
+
+x = -4 .+ 8 .* rand(2, 100)
+objf = x -> [ sum((x .- 1).^2); sum((x .+ 1).^2) ]
+fx = mapreduce(objf, hcat, eachcol(x))
+constr = x -> sum( (x).^2 ) - 0.5^2
+theta = max.(0, map(constr, eachcol(x)))
+
+ndset = NondominatedSet(Float64, Int[])
+init_nondom_set!(ndset, eachcol(fx), theta)
+rflags = ndset.extra
+#%%
+z = vcat(theta', fx)
+_z = vcat(theta[rflags]', fx[:, rflags])
+#%%
+mop = TP.to_mutable_mop(TP._test_problem(Val(6), 2))
+X = mop.lb .+ (mop.ub .- mop.lb) .* rand(2, 50)
+algo_opts = C.AlgorithmOptions(; max_iter=1)
+
+C.optimize_set(X, mop; algo_opts);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,11 +26,12 @@ end
 @safetestset "Matrix Factorizations" begin
     include("matrix_factorizations.jl")
 end
-
+#=
 @safetestset "Subproblems" begin
     include("suproblems.jl")
 end
-
+=#
+# TODO re-enable "Subproblems"
 @safetestset "Test Problems" begin
     include("testprobs.jl")
 end

--- a/test/testprobs.jl
+++ b/test/testprobs.jl
@@ -1,39 +1,44 @@
 using Compromise
 using Test
 include("TestProblems.jl")
-const TP = TestProblems
+TP = TestProblems
 #%%
 tp = TP._test_problem(Val(1), 2, Float64)
 mop = TP.to_mutable_mop(tp, :rbf)
 ret = optimize(mop, tp.x0)
-@test isapprox(sum(opt_vars(ret)), 1; rtol=1e-4)
+xopt = opt_vars(ret)
+@test xopt[1] ≈ xopt[2]
 
 #%%
 tp = TP._test_problem(Val(2), 3, Float64)
 mop = TP.to_mutable_mop(tp, :rbf)
 ret = optimize(mop, tp.x0)
-@test isapprox(sum(opt_vars(ret)), 1; rtol=1e-4)
+xopt = opt_vars(ret)
+@test sum(xopt) ≈ 1 rtol=1e-4
 @test all(tp.lb .<= opt_vars(ret) .<= tp.ub)
 
 #%%
 tp = TP._test_problem(Val(3), 3, Float64)
 mop = TP.to_mutable_mop(tp, :rbf)
 ret = optimize(mop, tp.x0)
-@test isapprox(sum(opt_vars(ret)), 1; rtol=1e-4)
+xopt = opt_vars(ret)
+@test sum(xopt) ≈ 1 rtol=1e-4
 @test all(tp.lb .<= opt_vars(ret) .<= tp.ub)
 @test all(tp.A * opt_vars(ret) .<= tp.b)
 #%%
 tp = TP._test_problem(Val(4), 3, Float64)
 mop = TP.to_mutable_mop(tp, :rbf)
 ret = optimize(mop, tp.x0)
-@test isapprox(sum(opt_vars(ret)), 1; rtol=1e-4)
+xopt = opt_vars(ret)
+@test sum(xopt) ≈ 1 rtol=1e-4
 @test all(tp.lb .<= opt_vars(ret) .<= tp.ub)
 @test all(tp.A * opt_vars(ret) .<= tp.b)
 #%%
 tp = TP._test_problem(Val(5), 3, Float64)
 mop = TP.to_mutable_mop(tp, :rbf)
 ret = optimize(mop, tp.x0)
-@test isapprox(sum(opt_vars(ret)), 1; rtol=1e-4)
+xopt = opt_vars(ret)
+@test sum(xopt) ≈ 1 rtol=1e-4
 @test all(tp.lb .<= opt_vars(ret) .<= tp.ub)
 @test all(tp.A * opt_vars(ret) .<= tp.b)
 #%%


### PR DESCRIPTION
This commit basically make `lin_cons` unnecessary.
We only need `scaled_cons` for step computation.
Makes reasoning about it a lot easier.
Like with restoration we can simply stay in the scaled domain.
Before, I did some mind-bending to align `A*ξ` (unscaled) and `_A*x` (scaled).
But we can simply work with the residual, which is the same (modulo roundoff) in unscaled and scaled domain.
I.e., use `Ax_min_b` and `Ex_min_c` for the step computation.

Also, we return after restoration now...